### PR TITLE
feat: set legacy sampling mode as default

### DIFF
--- a/src/chrome_update_digest/mcp/tools/enhanced_webplatform_digest.py
+++ b/src/chrome_update_digest/mcp/tools/enhanced_webplatform_digest.py
@@ -606,7 +606,7 @@ class EnhancedWebplatformDigestTool:
                 model_hint = str(run_preferences[0])
 
         # 🔧 Legacy mode: use simplified sampling approach (bypass message transformation)
-        USE_LEGACY_SAMPLING = os.getenv("USE_LEGACY_SAMPLING", "false").lower() == "true"
+        USE_LEGACY_SAMPLING = os.getenv("USE_LEGACY_SAMPLING", "true").lower() == "true"
         
         if USE_LEGACY_SAMPLING:
             if debug:


### PR DESCRIPTION
- Change USE_LEGACY_SAMPLING default from 'false' to 'true'
- Ensures sampling works out-of-the-box for all MCP server users
- No environment variable configuration needed for basic usage
- Users can still opt-out by setting USE_LEGACY_SAMPLING=false